### PR TITLE
Fix bug when editing game

### DIFF
--- a/api/controllers/gameController.ts
+++ b/api/controllers/gameController.ts
@@ -197,11 +197,11 @@ export class GameController {
       throw new HttpResponseError(400, `You didn't create this game!`);
     }
 
-    if (game.slots < game.players.length) {
+    if (body.slots < game.players.length) {
       throw new HttpResponseError(400, `You can't change the number of slots to less than the current number of players!`);
     }
 
-    if (game.humans < game.players.length) {
+    if (body.humans < game.players.length) {
       throw new HttpResponseError(400, `You can't change the number of humans to less than the current number of players!`);
     }
 

--- a/api/controllers/gameController.ts
+++ b/api/controllers/gameController.ts
@@ -197,15 +197,15 @@ export class GameController {
       throw new HttpResponseError(400, `You didn't create this game!`);
     }
 
-    if (body.slots < game.players.length) {
-      throw new HttpResponseError(400, `You can't change the number of slots to less than the current number of players!`);
-    }
-
-    if (body.humans < game.players.length) {
-      throw new HttpResponseError(400, `You can't change the number of humans to less than the current number of players!`);
-    }
-
     if (!game.inProgress) {
+      if (body.slots < game.players.length) {
+        throw new HttpResponseError(400, `You can't change the number of slots to less than the current number of players!`);
+      }
+
+      if (body.humans < game.players.length) {
+        throw new HttpResponseError(400, `You can't change the number of humans to less than the current number of players!`);
+      }
+
       game.displayName = body.displayName;
       game.description = body.description;
       game.slots = body.slots;


### PR DESCRIPTION
I was running into a bug when trying to edit my game. Just wanted to change the setting to let users join after the game has started and I was getting the error `You can't change the number of slots to less than the current number of players!`. This didn't make since there is no field for slots after the game has started. 

First, I realized that it was comparing `game.slots` with the amount of players instead of the `body.slots`. Though I'm still not sure how the game gets returned with less slots than the number of players.

Second, I changed the edit URL to only check the number of slots and humans if the game is not in progress. This made sense to me since you can only change `allowJoinAfterStart` and the password if the game has already started.