### PR TITLE
Add SteamId field in webhook content

### DIFF
--- a/functions/sns/userTurnNotification.ts
+++ b/functions/sns/userTurnNotification.ts
@@ -76,7 +76,9 @@ export class UserTurnNotification {
                     value2: user.displayName,
                     value3: game.round,
                     // Discourse webhook "content" field
-                    content: `It's ${user.displayName}'s turn in ${game.displayName} (Round ${game.round})`
+                    content: `It's ${user.displayName}'s turn in ${game.displayName} (Round ${game.round})`,
+                    // SteamId field included for use in custom webhooks
+                    steamId: user.steamId
                   })
                 },
                 true


### PR DESCRIPTION
When writing a custom webhook for PYDT I want to be able to maintain a mapping between my player's PYDT usernames and their Steam ID. This allows me to @ mention my players by their Discord name when messaging in our discord server about game updates. Presently I implement this in a sketchy way by mapping their "user.displayName" to their internal Discord ID. Since the "user.displayName" can change this makes these mappings difficult to manage.

Here's my custom webhook implementation, if you are curious: https://github.com/[geekman7473/PydtDiscordBot](https://github.com/geekman7473/PydtDiscordBot)

My group has been loving PYDT so far btw, we just got started with it earlier this week!

<img width="822" height="51" alt="image" src="https://github.com/user-attachments/assets/52dfdc01-dfd5-45ae-ae42-49f6b475843a" />
